### PR TITLE
password at start of print features

### DIFF
--- a/Marlin/src/feature/password/password.h
+++ b/Marlin/src/feature/password/password.h
@@ -41,6 +41,7 @@ public:
     private:
     static void authenticate_user(const screenFunc_t, const screenFunc_t);
     static void menu_password();
+    static void menu_password_rowan();
     static void menu_password_entry();
     static void screen_password_entry();
     static void screen_set_password();

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -782,7 +782,10 @@ namespace Language_en {
   LSTR MSG_START_OVER                     = _UxGT("Start Over");
   LSTR MSG_REMINDER_SAVE_SETTINGS         = _UxGT("Remember to Save!");
   LSTR MSG_PASSWORD_REMOVED               = _UxGT("Password Removed");
-
+  LSTR MSG_ROWAN_CONFIG                   = _UxGT("INCORRECT CONFIG");
+  LSTR MSG_ROWAN_INSTRUCT                 = _UxGT("Follow directions at:");
+  LSTR MSG_ROWAN_URL                      = _UxGT("go.rowan.edu/meshop");
+  LSTR MSG_ROWAN_RESET                    = _UxGT("& reboot this printer");
   //
   // Filament Change screens show up to 3 lines on a 4-line display
   //                        ...or up to 2 lines on a 3-line display

--- a/Marlin/src/lcd/menu/menu_password.cpp
+++ b/Marlin/src/lcd/menu/menu_password.cpp
@@ -40,38 +40,61 @@ bool authenticating; // = false
 char string[(PASSWORD_LENGTH) + 1];
 static uint8_t digit_no;
 
+// 
+// Screen for Rowan custom display of requirements
+// 
+
+void Password::menu_password_rowan() {
+    ui.defer_status_screen(!did_first_run); // No timeout to status before first auth
+
+  START_MENU();
+
+  // "Talk students through what they did wrong"
+  STATIC_ITEM_F(GET_TEXT_F(MSG_ROWAN_CONFIG), SS_CENTER|SS_INVERT);
+  STATIC_ITEM_F(GET_TEXT_F(MSG_ROWAN_INSTRUCT), SS_CENTER);
+  STATIC_ITEM_F(GET_TEXT_F(MSG_ROWAN_URL), SS_CENTER);
+  STATIC_ITEM_F(GET_TEXT_F(MSG_ROWAN_RESET), SS_CENTER);
+
+  END_MENU();
+}
+
+
 //
 // Screen for both editing and setting the password
 //
 void Password::menu_password_entry() {
-  ui.defer_status_screen(!did_first_run); // No timeout to status before first auth
+  #ifdef ROWAN_PASSWORD_FEATURE
+    menu_password_rowan();
+  #else
+    ui.defer_status_screen(!did_first_run); // No timeout to status before first auth
 
-  START_MENU();
+    START_MENU();
 
-  // "Login" or "New Code"
-  STATIC_ITEM_F(authenticating ? GET_TEXT_F(MSG_LOGIN_REQUIRED) : GET_TEXT_F(MSG_EDIT_PASSWORD), SS_CENTER|SS_INVERT);
+    // "Login" or "New Code"
+    STATIC_ITEM_F(authenticating ? GET_TEXT_F(MSG_LOGIN_REQUIRED) : GET_TEXT_F(MSG_EDIT_PASSWORD), SS_CENTER|SS_INVERT);
 
-  STATIC_ITEM_F(FPSTR(NUL_STR), SS_CENTER, string);
+    STATIC_ITEM_F(FPSTR(NUL_STR), SS_CENTER, string);
 
-  #if HAS_MARLINUI_U8GLIB
-    STATIC_ITEM_F(FPSTR(NUL_STR), SS_CENTER, "");
+    #if HAS_MARLINUI_U8GLIB
+      STATIC_ITEM_F(FPSTR(NUL_STR), SS_CENTER, "");
+    #endif
+
+    // Make the digit edit item look like a sub-menu
+    FSTR_P const label = GET_TEXT_F(MSG_ENTER_DIGIT);
+    EDIT_ITEM_F(uint8, label, &editable.uint8, 0, 9, digit_entered);
+    MENU_ITEM_ADDON_START(utf8_strlen(label) + 1);
+      lcd_put_u8str(F(" "));
+      lcd_put_lchar('1' + digit_no);
+      SETCURSOR_X(LCD_WIDTH - 2);
+      lcd_put_u8str(F(">"));
+    MENU_ITEM_ADDON_END();
+
+    ACTION_ITEM(MSG_START_OVER, start_over);
+
+    if (!authenticating) BACK_ITEM(MSG_BUTTON_CANCEL);
+
+    END_MENU();
   #endif
-
-  // Make the digit edit item look like a sub-menu
-  FSTR_P const label = GET_TEXT_F(MSG_ENTER_DIGIT);
-  EDIT_ITEM_F(uint8, label, &editable.uint8, 0, 9, digit_entered);
-  MENU_ITEM_ADDON_START(utf8_strlen(label) + 1);
-    lcd_put_u8str(F(" "));
-    lcd_put_lchar('1' + digit_no);
-    SETCURSOR_X(LCD_WIDTH - 2);
-    lcd_put_u8str(F(">"));
-  MENU_ITEM_ADDON_END();
-
-  ACTION_ITEM(MSG_START_OVER, start_over);
-
-  if (!authenticating) BACK_ITEM(MSG_BUTTON_CANCEL);
-
-  END_MENU();
 }
 
 //

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -556,9 +556,13 @@ void CardReader::release() {
  */
 void CardReader::openAndPrintFile(const char *name) {
   char cmd[4 + strlen(name) + 1 + 3 + 1]; // Room for "M23 ", filename, "\n", "M24", and null
-  sprintf_P(cmd, M23_STR, name);
-  for (char *c = &cmd[4]; *c; c++) *c = tolower(*c);
+  #if ENABLED(PASSWORD_AFTER_SD_PRINT_START)
+    cmd = 4 + strlen(name) + 1 + 3 + 1 + 4 + 1; // Room for "M23 ", filename, "\n", "M24", "\n", "M510", and null
+  #endif
   strcat_P(cmd, PSTR("\nM24"));
+  #if ENABLED(PASSWORD_AFTER_SD_PRINT_START)
+    strcat_P(cmd, PSTR("\nM510")); // Lock expecting the student printer to unlock.
+  #endif
   queue.inject(cmd);
 }
 

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -555,9 +555,10 @@ void CardReader::release() {
  * Enqueues M23 and M24 commands to initiate a media print.
  */
 void CardReader::openAndPrintFile(const char *name) {
-  char cmd[4 + strlen(name) + 1 + 3 + 1]; // Room for "M23 ", filename, "\n", "M24", and null
   #if ENABLED(PASSWORD_AFTER_SD_PRINT_START)
-    cmd = 4 + strlen(name) + 1 + 3 + 1 + 4 + 1; // Room for "M23 ", filename, "\n", "M24", "\n", "M510", and null
+    char cmd[4 + strlen(name) + 1 + 3 + 1 + 4 + 1]; // Room for "M23 ", filename, "\n", "M24", "\n", "M510", and null
+  #else
+    char cmd[4 + strlen(name) + 1 + 3 + 1]; // Room for "M23 ", filename, "\n", "M24", and null
   #endif
   strcat_P(cmd, PSTR("\nM24"));
   #if ENABLED(PASSWORD_AFTER_SD_PRINT_START)


### PR DESCRIPTION
integrate expectation of password at the start of a print, provided by the slicer rather than user input

before merge must:
- lock the printer at the start of loading a file
- allow buffered codes through a lock if they are not already
- change the password entry screen to direct users to the configuration webpage
- instruct users to restart the printer
- disallow entry of the password at above screen

nice to have:
- qr code display of the configuration webpage